### PR TITLE
Typo fix in dotgo post

### DIFF
--- a/content/post/dot_go_2015.md
+++ b/content/post/dot_go_2015.md
@@ -10,21 +10,21 @@ I would like to introduce you to my new mates, the **source{d}** dev team...
 
 ![The source{d} dev team during one of our daily stand-ups.](/post/dot_go_2015/dev_team.jpg)
 
-As you can guess by the photo, we've been pretty exited about [dotGo](http://www.dotgo.eu/), "The European Go Conference", that took place in Paris on November 9, 2015.
+As you can guess by the photo, we've been pretty excited about [dotGo](http://www.dotgo.eu/), "The European Go Conference", that took place in Paris on November 9, 2015.
 
 We arrived in Paris the night before the event, the weather was nice, the spirits high and the gophers looked pretty relaxed, doing the kind of things gophers do when there are no goroutines to manage.
 
 I was a little concerned about the fact that the titles of the talks hadn't been announced, but hey!, it's **"The European Go Conference"**, right?, it is going to be amazing no matter what... Well, it wasn't, at least not for me; the technical level of the talks was, in general, pretty low, and in some cases even inexistent.
 
-One cannot honestly complain about undelivered expectations considering that the titles of the talks were unknown, but according to the conference's website *"you can expect deeply technical talks (even more than previous dotConferences) and surprising new ideas!"*. I cannot say dotGo fulfilled that promise. 
+One cannot honestly complain about undelivered expectations considering that the titles of the talks were unknown, but according to the conference's website *"you can expect deeply technical talks (even more than previous dotConferences) and surprising new ideas!"*. I cannot say dotGo fulfilled that promise.
 
-On the bright side, I found [Anthony Starks](https://github.com/ajstarks)' talk about art and code extremely enjoyable. He's a great speaker and his talk was refreshing and interesting.  
+On the bright side, I found [Anthony Starks](https://github.com/ajstarks)' talk about art and code extremely enjoyable. He's a great speaker and his talk was refreshing and interesting.
 
 I also enjoyed [Francesc Campoy](https://github.com/campoy)'s Functional Go talk. He began by setting out a clear and simple problem statement and walked us through his solution, step by step, with a well-paced presentation.  Approaching Go from a functional perspective may not be very efficient, but it was an excellent way to get my brain in the (tech) mood.
 
 One of Go's strongest points is its tool ecosystem, and [Fatih Arslan](https://github.com/fatih)'s talk was a nice update on the current state of the art of Go tools.
 
-Writing in detail about the talks would be an exercise in futility, since you'll be able to watch them all on [dotconferences](http://www.dotconferences.eu/) and [YouTube](http://www.youtube.com) in a few days, so let me finish this post by relaying what you won't be able to see for yourself. The **Théâtre de Paris** is an amazing venue, the place looks beautiful, acoustics were fine and the seats were comfortable. The staff and volunteers did a terrific job and the catering was excellent, both in quality, as well as in quantity. 
+Writing in detail about the talks would be an exercise in futility, since you'll be able to watch them all on [dotconferences](http://www.dotconferences.eu/) and [YouTube](http://www.youtube.com) in a few days, so let me finish this post by relaying what you won't be able to see for yourself. The **Théâtre de Paris** is an amazing venue, the place looks beautiful, acoustics were fine and the seats were comfortable. The staff and volunteers did a terrific job and the catering was excellent, both in quality, as well as in quantity.
 
 ![The house as seen from the stage.](/post/dot_go_2015/venue.jpg)
 ![The lobby.](/post/dot_go_2015/food.jpg)


### PR DESCRIPTION
  * s/exited/excited/
  * trim trailing space (unless you want this, let me know I can revert.)