### PR TITLE
Define categories for json exports

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,21 +1,25 @@
 # Configuration
-HUGO_VERSION ?= 0.14
+HUGO_VERSION ?= 0.17
 HUGO_THEME ?= ""
 GIT_COMMITTER_NAME ?= autohugo
 GIT_COMMITTER_EMAIL ?= autohugo@autohugo.local
 CNAME ?= ""
 
 # System
+URL_OS = 64bit
 OS = amd64
 ifeq ($(OS),Windows_NT)
     ARCH = windows
+    URL_ARCH = Windows
 else
     UNAME_S := $(shell uname -s)
     ifeq ($(UNAME_S),Linux)
 			ARCH = linux
+			URL_ARCH = Linux
     endif
     ifeq ($(UNAME_S),Darwin)
 			ARCH = darwin
+			URL_ARCH = MacOS
     endif
 endif
 
@@ -30,6 +34,7 @@ THEME_PATH := $(THEMES_PATH)/$(THEME_NAME)
 HUGO_PATH := $(BASE_PATH)/.hugo
 HUGO_URL = github.com/spf13/hugo
 HUGO_NAME := hugo_$(HUGO_VERSION)_$(ARCH)_$(OS)
+HUGO_URL_NAME := hugo_$(HUGO_VERSION)_$(URL_ARCH)-$(URL_OS)
 
 # Tools
 CURL = curl -L
@@ -53,7 +58,7 @@ dependencies: init
 		ext="zip"; \
 		if [ "$(ARCH)" == "linux" ]; then ext="tar.gz"; fi; \
 		file="hugo.$${ext}"; \
-		$(CURL) https://$(HUGO_URL)/releases/download/v$(HUGO_VERSION)/$(HUGO_NAME).$${ext} -o $${file}; \
+		$(CURL) https://$(HUGO_URL)/releases/download/v$(HUGO_VERSION)/$(HUGO_URL_NAME).$${ext} -o $${file}; \
 		if [ "$(ARCH)" == "linux" ]; then tar -xvzf $${file}; else unzip $${file}; fi; \
 	fi;
 	@if [[ ! -d $(THEME_PATH) ]]; then \

--- a/circle.yml
+++ b/circle.yml
@@ -1,6 +1,6 @@
 machine:
   environment:
-    HUGO_VERSION: 0.15
+    HUGO_VERSION: 0.17
     HUGO_THEME: https://github.com/digitalcraftsman/hugo-steam-theme
     CNAME: blog.sourced.tech
 

--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,9 @@
 title: source{d} blog
 baseUrl: /
 
+taxonomies:
+  category: "categories"
+
 params:
   description: coding to find awesome engineers
   copyright: The MIT License. - Copyright (c) 2015 Máximo Cuadros

--- a/content/json/business.md
+++ b/content/json/business.md
@@ -1,0 +1,3 @@
+---
+title: business
+---

--- a/content/json/business.md
+++ b/content/json/business.md
@@ -1,3 +1,0 @@
----
-title: business
----

--- a/content/json/culture.md
+++ b/content/json/culture.md
@@ -1,0 +1,3 @@
+---
+title: culture
+---

--- a/content/json/science.md
+++ b/content/json/science.md
@@ -1,0 +1,3 @@
+---
+title: science
+---

--- a/content/json/technical.md
+++ b/content/json/technical.md
@@ -1,0 +1,3 @@
+---
+title: technical
+---

--- a/content/post/100-awesome-women-in-the-open-source-community-you-should-know.md
+++ b/content/post/100-awesome-women-in-the-open-source-community-you-should-know.md
@@ -5,7 +5,7 @@ title: "100 Awesome Women In The Open-Source Community You Should Know"
 draft: false 
 image: /post/100-awesome-women-in-the-open-source-community-you-should-know/intro.jpg 
 description: "100 Awesome Women In The Open-Source Community You Should Know" 
-categories: ["business"] 
+categories: ["culture"] 
 ---
 <link rel="stylesheet" type="text/css" href="/post/100-awesome-women-in-the-open-source-community-you-should-know/post-style.css">
 

--- a/content/post/100-awesome-women-in-the-open-source-community-you-should-know.md
+++ b/content/post/100-awesome-women-in-the-open-source-community-you-should-know.md
@@ -1,11 +1,12 @@
---- 
+---
 author: eiso 
 date: 2016-05-25 
 title: "100 Awesome Women In The Open-Source Community You Should Know" 
 draft: false 
 image: /post/100-awesome-women-in-the-open-source-community-you-should-know/intro.jpg 
 description: "100 Awesome Women In The Open-Source Community You Should Know" 
---- 
+categories: ["business"] 
+---
 <link rel="stylesheet" type="text/css" href="/post/100-awesome-women-in-the-open-source-community-you-should-know/post-style.css">
 
 

--- a/content/post/coreos_nano.md
+++ b/content/post/coreos_nano.md
@@ -5,6 +5,7 @@ title: "Native GNU nano text editor in CoreOS."
 draft: false
 image: /post/coreos_nano/nano_intro.png
 description: "CoreOS ships with Vim as the only text editor by default. The following is how to compile GNU nano text editor for CoreOS as a first-class citizen."
+categories: ["technical"] 
 ---
 Sometimes, you want to edit text files inside CoreOS. Either you have to use the Vim
 editor which is shipped by default or use a container, e.g. Toolbox. I am not a fan

--- a/content/post/cuda_ldconfig.md
+++ b/content/post/cuda_ldconfig.md
@@ -5,6 +5,7 @@ title: "Never mess with LD_LIBRARY_PATH to run your CUDA app again"
 draft: false 
 image: /post/cuda_ldconfig/intro.png
 description: "Simple and easy way to install CUDA and CUDNN system-wide." 
+categories: ["science", "technical"]
 --- 
 
 If you are using [CUDA](https://en.wikipedia.org/wiki/CUDA) on Linux then

--- a/content/post/dataproc_jupyter.md
+++ b/content/post/dataproc_jupyter.md
@@ -5,6 +5,7 @@ title: "Setting up Google Cloud Dataproc with Jupyter and Python 3 stack"
 draft: false
 image: /post/dataproc_jupyter/intro.png
 description: "How-to article devoted to setting up Dataproc, Jupyter and Python 3 data science stack"
+categories: ["science", "technical"]
 ---
 Modern big data world is hard to imagine without [Hadoop](http://hadoop.apache.org/).
 It made a small revolution in how analysts deal with large amount of emerging data

--- a/content/post/dataproc_lzo.md
+++ b/content/post/dataproc_lzo.md
@@ -5,6 +5,7 @@ title: "Adding LZO support to Dataproc"
 draft: false
 image: /post/dataproc_lzo/intro.png
 description: "How to leverage splittable LZO compression in Dataproc"
+categories: ["science", "technical"]
 ---
 [LZO](https://en.wikipedia.org/wiki/Lempel%E2%80%93Ziv%E2%80%93Oberhumer) is a nice
 general-purpose data compression algorithm which provides blazing fast decompression.

--- a/content/post/deep_learning_summit.md
+++ b/content/post/deep_learning_summit.md
@@ -4,6 +4,7 @@ date: 2015-10-19
 title: Notes on the Deep Learning Summit London 2015
 image: /post/deep_learning_summit/intro.png
 description: "Finding the most appropriate developers for a job offer is a very tough task, as proven by the plethora of tech recruiters that seem to be constantly shooting in the dark or outright lost."
+categories: ["science", "technical"]
 ---
 
 ![Logo](/post/deep_learning_summit/intro.png)

--- a/content/post/dot_go_2015.md
+++ b/content/post/dot_go_2015.md
@@ -4,6 +4,7 @@ date: 2015-11-13
 title: "dotGo2015: Undelivered Expectations"
 image: /post/dot_go_2015/intro.jpg
 description: "dotGo 2015, an excellent venue, not-so-techy talks."
+categories: ["business"]
 ---
 
 I would like to introduce you to my new mates, the **source{d}** dev team...

--- a/content/post/dot_go_2015.md
+++ b/content/post/dot_go_2015.md
@@ -4,7 +4,7 @@ date: 2015-11-13
 title: "dotGo2015: Undelivered Expectations"
 image: /post/dot_go_2015/intro.jpg
 description: "dotGo 2015, an excellent venue, not-so-techy talks."
-categories: ["business"]
+categories: ["culture"]
 ---
 
 I would like to introduce you to my new mates, the **source{d}** dev team...

--- a/content/post/github_stars.md
+++ b/content/post/github_stars.md
@@ -5,6 +5,7 @@ title: "Hands on with the most starred GitHub repositories."
 draft: false
 image: /post/github_stars/star.png
 description: "Playing with most popular repositories' metadata."
+categories: ["science", "technical"]
 ---
 Recently I started to collect all the available metadata (name,
 number of stars, forks, watchers, etc.) from the most popular GitHub repositories.

--- a/content/post/github_stats.md
+++ b/content/post/github_stats.md
@@ -5,6 +5,7 @@ title: "Fun with GitHub repositories statistics."
 draft: false 
 image: /post/github_stats/go.png
 description: "Lots of histograms plotted for GitHub data collected by source{d}." 
+categories: ["science", "technical"]
 ---
 
 It's always fun to play with a dataset few people have ever played with.

--- a/content/post/github_topic_modeling.md
+++ b/content/post/github_topic_modeling.md
@@ -5,6 +5,7 @@ title: "Topic Modeling of GitHub Repositories"
 draft: false
 image: /post/github_topic_modeling/wordcloud.png
 description: "Data mining of 18M GitHub repositories"
+categories: ["science", "technical"]
 ---
 [Topic modeling](https://en.wikipedia.org/wiki/Topic_model) is the machine learning
 subdomain which is devoted to extracting abstract "topics" from a collection of "documents".

--- a/content/post/kmcuda4.md
+++ b/content/post/kmcuda4.md
@@ -5,6 +5,7 @@ title: "kmcuda (K-Means on GPU) version 4 is released"
 draft: false
 image: /post/kmcuda4/nvprof.png
 description: "Our kmcuda v4 is released, featuring multi-gpu, float16, Spherical K-Means and improved precision."
+categories: ["science", "technical"]
 ---
 
 Some time ago, I wrote an article about [src-d/kmcuda](https://github.com/src-d/kmcuda)

--- a/content/post/meetup-blame.md
+++ b/content/post/meetup-blame.md
@@ -4,6 +4,7 @@ date: 2016-02-15
 title: "Levenshtein distance, LCS, diff and blame"
 image: /post/meetup-blame/intro.jpg
 description: "Papers we love Madrid Meetup: Levenshtein distance, LCS, diff and blame."
+categories: ["technical"]
 ---
 
 There are some interesting [meetups](http://www.meetup.com) going on in Madrid,

--- a/content/post/minhashcuda.md
+++ b/content/post/minhashcuda.md
@@ -5,6 +5,7 @@ title: "Weighted MinHash on GPU helps to find duplicate GitHub repositories."
 draft: false
 image: /post/minhashcuda/benders.jpg
 description: "We describe how we filtered very similar GitHub repositories using our new open source project MinHashCuda."
+categories: ["science", "technical"]
 ---
 The codez: [GitHub](https://github.com/src-d/minhashcuda).
 

--- a/content/post/reactmad-redux.md
+++ b/content/post/reactmad-redux.md
@@ -4,6 +4,7 @@ date: 2016-02-05
 title: "First ReactMad meetup: Time travelling with React and Redux"
 image: /post/reactmad-redux/back.jpg
 description: "An introduction to Redux and its time traveling capabilities for debugging."
+categories: ["technical"]
 ---
 ![View from the back of the room](/post/reactmad-redux/back.jpg)
 

--- a/content/post/reading_pyspark_pickles_locally.md
+++ b/content/post/reading_pyspark_pickles_locally.md
@@ -5,7 +5,7 @@ title: "Reading PySpark pickles locally"
 draft: false
 image: /post/reading_pyspark_pickles_locally/intro.jpg
 description: "How to load Hadoop SequenceFile-s with Python serialized objects without having to install Spark - using src-d/sparkpickle"
-categories: ["science", "technical"]
+categories: ["technical"]
 ---
 I've recently had a task to merge all the output from Spark in the Pickle format,
 that is, obtained via `spark.rdd.RDD.saveAsPickleFile()`, in my personal environment

--- a/content/post/reading_pyspark_pickles_locally.md
+++ b/content/post/reading_pyspark_pickles_locally.md
@@ -5,6 +5,7 @@ title: "Reading PySpark pickles locally"
 draft: false
 image: /post/reading_pyspark_pickles_locally/intro.jpg
 description: "How to load Hadoop SequenceFile-s with Python serialized objects without having to install Spark - using src-d/sparkpickle"
+categories: ["science", "technical"]
 ---
 I've recently had a task to merge all the output from Spark in the Pickle format,
 that is, obtained via `spark.rdd.RDD.saveAsPickleFile()`, in my personal environment

--- a/content/post/retreat-story.md
+++ b/content/post/retreat-story.md
@@ -4,6 +4,7 @@ date: 2015-10-12
 title: Taking Coding to the Mountains
 image: /post/retreat-story/9239.jpg
 description: "The Tyba engineers enjoyed a wonderful experience these last days of summer: spending two days in a country house, far away from the madding crowds, to participate in an Open Source Hackaton."
+categories: ["business"] 
 ---
 
 The Tyba engineers enjoyed a wonderful experience these last days of summer: spending two days in a country house, far away from the madding crowds, to participate in an **Open Source Hackaton**. The venue, a beautiful villa located in [Guadalix de la Sierra](https://www.google.es/maps/place/28794+Guadalix+de+la+Sierra,+Madrid/@40.7834355,-3.6965663,15z/data=!3m1!4b1!4m2!3m1!1s0xd43d9017d147909:0x1a4e541fa536a900?hl=en)– promised both a nice place to work, as well as lots of fun in the spare time.

--- a/content/post/retreat-story.md
+++ b/content/post/retreat-story.md
@@ -4,7 +4,7 @@ date: 2015-10-12
 title: Taking Coding to the Mountains
 image: /post/retreat-story/9239.jpg
 description: "The Tyba engineers enjoyed a wonderful experience these last days of summer: spending two days in a country house, far away from the madding crowds, to participate in an Open Source Hackaton."
-categories: ["business"] 
+categories: ["culture"] 
 ---
 
 The Tyba engineers enjoyed a wonderful experience these last days of summer: spending two days in a country house, far away from the madding crowds, to participate in an **Open Source Hackaton**. The venue, a beautiful villa located in [Guadalix de la Sierra](https://www.google.es/maps/place/28794+Guadalix+de+la+Sierra,+Madrid/@40.7834355,-3.6965663,15z/data=!3m1!4b1!4m2!3m1!1s0xd43d9017d147909:0x1a4e541fa536a900?hl=en)– promised both a nice place to work, as well as lots of fun in the spare time.

--- a/content/post/tab_vs_spaces.md
+++ b/content/post/tab_vs_spaces.md
@@ -5,6 +5,7 @@ title: "397 Languages, 18,000,000 GitHub repositories, 1.2 billion files, 20 ter
 draft: false
 image: /post/tab_vs_spaces/intro.png
 description: "Comprehensive study of spaces and tabs usage in source code in GitHub repositories"
+categories: ["science", "technical"]
 ---
 Tabs or spaces. We are going to parse every file among all programming languages known by GitHub to decide which one is on top.
 

--- a/content/post/towards_kmeans_on_gpu.md
+++ b/content/post/towards_kmeans_on_gpu.md
@@ -4,6 +4,7 @@ date: 2016-07-26
 title: Towards Yinyang K-means on GPU
 image: /post/towards_kmeans_on_gpu/intro.png
 description: "K-means is a nice and simple clustering algorithm. It can be effectively implemented using NVIDIA CUDA technology and we elaborate on how."
+categories: ["science", "technical"]
 ---
 
 The codez: [GitHub](https://github.com/src-d/kmcuda).

--- a/layouts/json/single.html
+++ b/layouts/json/single.html
@@ -1,0 +1,7 @@
+{{ $pages := index .Site.Taxonomies.categories .Title }}
+{"Posts": [
+  {{ range $k, $post := (sort $pages.Pages "Date" "desc") }}
+    {{if $k}},{{end}}
+    {{ dict "title" $post.LinkTitle "description" $post.Description "link" $post.Permalink "date" ($post.Date.Format "Mon, 02 Jan 2006 15:04:05 -0700" | safeHTML) | jsonify }}
+  {{ end }}
+]}


### PR DESCRIPTION
The most relevant change is that once approved, the posts can be categorized by scope;
current categories are **technical**, science, programming and **culture** (for non-technical posts)
The system will accept many different categories for the same post; those proposed or any other.

#### Does it have any implication:
- Blog -> no implications, there is no category shown in the blog at this moment nor after approving the PR
- WEB -> YES. The new landing HP will show (separately) the first "n" posts from "**technical**" and "**culture**" categories

#### As a blog post writter, should you know something?
Yes. Maybe some posts should appear in the Landing, and other posts should not; In that case, only certain posts should be categorized with "**technical**" or "**culture**" ; It should be confirmed by the PM in order to have a guideline about it; anyway, it is not related with the approval of this PR :D

#### What about other categories as **science** or **programming**?
They are not used currently, but it could be a good idea to use them in case of further use

#### How will be those categories exposed?
Once approved the PR, the allowed categories will be exposed under 
http://blog.sourced.tech/json/CATEGORY_NAME
