### PR TITLE
remove parents from image comment (they break markdown)

### DIFF
--- a/content/post/difftree.md
+++ b/content/post/difftree.md
@@ -19,7 +19,7 @@ p.dt {
 }
 </style>
 
-![Front image](/post/difftree/intro.jpg "Old Trees, copyright (c) 2015 by Moises Levy, http://www.moiseslevy.com/Old%20Trees")
+![Front image](/post/difftree/intro.jpg "Old Trees, copyright 2015 by Moises Levy, http://www.moiseslevy.com/Old%20Trees")
 
 ## Introduction
 


### PR DESCRIPTION
Sorry, apparently parents break image captions.