### PR TITLE
Remove use of BaseURL in templates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ HUGO_VERSION ?= 0.17
 HUGO_THEME ?= https://github.com/digitalcraftsman/hugo-steam-theme
 DOCKER_ORG ?= quay.io/srcd
 
+BASE_URL ?= "//localhost:1313/"
+
 DOCKER_REGISTRY ?= quay.io
 DOCKER_USERNAME ?=
 DOCKER_PASSWORD ?=
@@ -82,12 +84,12 @@ dependencies: init
 
 foo:
 	echo $(TAG)
- 
+
 build: dependencies
-	$(HUGO) -t $(THEME_NAME)
+	$(HUGO) -t $(THEME_NAME) --baseURL $(BASE_URL)
 
 server: build
-	$(HUGO) server -t $(THEME_NAME) -D -w
+	$(HUGO) server -t $(THEME_NAME) -D -w --baseURL $(BASE_URL)
 
 docker-push: build
 	$(DOCKER) login -u "$(DOCKER_USERNAME)" -p "$(DOCKER_PASSWORD)" $(DOCKER_REGISTRY)

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,4 @@
 title: source{d} blog
-baseUrl: /
 theme: hugo-steam-theme
 
 taxonomies:

--- a/themes/hugo-steam-theme/layouts/partials/footer.html
+++ b/themes/hugo-steam-theme/layouts/partials/footer.html
@@ -7,9 +7,8 @@
 		    {{ with .Site.Params.github }}
 		    <a href="//github.com/{{ . }}" target="_blank" title="GitHub"><i class="fa fa-2x fa-fw fa-github"></i> <span class="hidden">GitHub</span></a>&nbsp;
 		    {{ end }}
-		    <!--<a href="{{ .Site.BaseURL }}index.xml" target="_blank" title="RSS"><i class="fa fa-2x fa-fw fa-rss"></i> <span class="hidden">RSS</span></a>-->
 		</section>
 
-		<section class="copyright">&copy; {{.Now.Format "2006"}} <a href="{{ .Site.BaseURL }}">{{ .Site.Params.name }}</a>. {{ .Site.Params.copyright | markdownify }}</section>
+		<section class="copyright">&copy; {{.Now.Format "2006"}} <a href="{{ relURL "/" }}">{{ .Site.Params.name }}</a>. {{ .Site.Params.copyright | markdownify }}</section>
 	</div>
 </footer>

--- a/themes/hugo-steam-theme/layouts/partials/head.html
+++ b/themes/hugo-steam-theme/layouts/partials/head.html
@@ -16,12 +16,12 @@
       <link href="{{ .RSSLink }}" rel="feed" type="application/rss+xml" title="{{ .Site.Title }}" />
     {{ end }}
 
-    <link rel="shortcut icon" href="{{ .Site.BaseURL }}img/favicon.ico">
+    <link rel="shortcut icon" href="{{ relURL "/img/favicon.ico" }}">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/normalize/2.1.2/normalize.min.css">
 
     {{ "<!-- Stylesheets -->" | safeHTML }}
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/screen.css">
-    <link rel="stylesheet" href="{{ .Site.BaseURL }}css/github.css">
+    <link rel="stylesheet" href="{{ relURL "/css/screen.css" }}">
+    <link rel="stylesheet" href="{{ relURL "/css/github.css" }}">
     <link rel="stylesheet" href="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.3/styles/default.min.css">
 
     <link href="https://fonts.googleapis.com/css?family=Lato:300,400,700|Roboto:300,400,700" rel="stylesheet">

--- a/themes/hugo-steam-theme/layouts/partials/header.html
+++ b/themes/hugo-steam-theme/layouts/partials/header.html
@@ -1,7 +1,7 @@
 <header id="site-head">
 	{{ with .Site.Params.title }}
 	<h1 class="blog-title">
-		<a href="{{ $.Site.BaseURL }}">
+		<a href="{{ relURL "/" }}">
 			<img class="logoImage" src="/image/logo/sourced_blog_logo.svg" alt="source{d} | blog" title="source{d} | blog" />
 		</a>
 	</h1>

--- a/themes/hugo-steam-theme/layouts/partials/js.html
+++ b/themes/hugo-steam-theme/layouts/partials/js.html
@@ -1,6 +1,6 @@
 <script src="//cdnjs.cloudflare.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-<script src="{{ .Site.BaseURL }}js/index.js"></script>
-<script src="{{ .Site.BaseURL }}js/smooth-scroll.min.js"></script>
+<script src="{{ relURL "/js/index.js" }}"></script>
+<script src="{{ relURL "/js/smooth-scroll.min.js" }}"></script>
 <script src="//cdnjs.cloudflare.com/ajax/libs/highlight.js/8.3/highlight.min.js"></script>
 
 <script>


### PR DESCRIPTION
BaseURL is no more in templates, in its place, we use `relURL` now.
Furthermore, I removed the baseurl from the configuration to force it to
be one.

I already added a configuration to travis.