### PR TITLE
fix json when there are upcoming posts

### DIFF
--- a/layouts/json/single.html
+++ b/layouts/json/single.html
@@ -1,8 +1,13 @@
 {{ $pages := index .Site.Taxonomies.categories .Title }}
+{{ $.Scratch.Set "first" true }}
 {"Posts": [
     {{ range $k, $post := sort $pages.Pages "Date" "desc" }}
         {{if eq $post.Type "post"}}
-            {{if $k}},{{end}}
+            {{if $.Scratch.Get "first"}}
+                {{ $.Scratch.Set "first" false }}
+            {{ else }}
+                ,
+            {{end}}
 
             {{ if default false $post.Params.image }}
                 {{ $.Scratch.Set "image" (absURL $post.Params.image) }}


### PR DESCRIPTION
If the first posts is not of type "post" there's a leading comma that makes it invalid JSON, as it is the case now: http://blog.sourced.tech/json/technical

/cc @Serabe 