### PR TITLE
Id2vec

### DIFF
--- a/content/documentation/shortcodes.md
+++ b/content/documentation/shortcodes.md
@@ -104,13 +104,15 @@ Whenever you need to use an image in your post, you should consider the `caption
 For the caption of the image, it can be used html, markdown and other shortcodes
 
 ```
-{{%/* caption src="//url-to-the-omage" title="title of image" %}}
+{{%/* caption src="//url-to-the-omage" title="title of image" width="half-width" %}}
 caption of the image
 {{% /caption */%}}
 ```
 
+The modifier `width="half-width"` is optional, and will display a 50% width image if used.
+
 _example_:
-{{% caption src="http://www.elreferente.es/source/paginas/slider/sourced-ronda-6millones.jpg" title="title of image" %}}
+{{% caption src="http://www.elreferente.es/source/paginas/slider/sourced-ronda-6millones.jpg" title="title of image"  width="half-width" %}}
 caption of the image
 {{% /caption %}}
 

--- a/content/documentation/shortcodes.md
+++ b/content/documentation/shortcodes.md
@@ -65,6 +65,38 @@ _example_:
 This content will be centerd
 {{% /center %}}
 
+## Text
+
+The `text` shortcode lets you choose between small and large font. To use it, wrap your content with the `text` shortcode, and specify the desired size.
+
+```
+{{%/* text size="__SIZE__" font="monospaced" */%}}
+Text to be modified
+{{%/* /text */%}}
+```
+
+**NOTES:**
+
+- The available sizes are: `large` and `small`.
+- The available font family is: `monospaced`.
+- The shortcode creates a new block, so it can not be used for _inline_ content.
+- This shortcode should not be used instead of markdown native headings.
+- A `text` shortcodes should not be nested inside other `text` shortcode.
+
+_example_:
+{{% text size="large" font="monospaced" %}}
+This text was made large and monospaced
+{{% /text %}}
+
+{{% text size="large" %}}
+This text was made large
+{{% /text %}}
+
+{{% text size="small" %}}
+This text was made small
+{{% /text %}}
+
+
 ## Caption
 
 Whenever you need to use an image in your post, you should consider the `caption` shortcode to provide valuable information to the user; think in the screen readers.
@@ -179,6 +211,89 @@ The parameters the `codepen` shortcode accepts are:
 
 _example_:
 {{% codepen slug="ayEKKj" title="lapjv" %}}
+
+## table
+
+Whenever it is neede to modify a markdown table, it must be done by the `table` shortcode. That shortcode allows only some modifications tan tan be combined or not adding some _modifiers_ to the shortcode.
+
+To use it, just wrap your table by the `table` shortcode with the desired _modifiers_
+
+```
+{{%/* table "noCellHighlighting" "noHeader" "fixedLayout" "condensed" "center" */%}}
+
+header1 | long-header-2
+--- | ---
+1 | 2
+3 | 4
+
+{{%/* /table */%}}
+```
+
+Available _modifiers_:
+
+- `noCellHighlighting`: removes the borders and backgrounds from the table
+- `noHeader`: removes the header from the table
+- `fixedLayout`: enables the table render mode "table-layout:fixed"
+- `condensed`: reduces the cells padding
+- `center`: reduces the cells padding
+
+
+_examples_:
+
+{{% grid %}}
+{{% grid-cell %}}
+no _modifiers_:
+
+header1 | long-header-2
+--- | ---
+1 | 2
+3 | 4
+
+{{% /grid-cell %}}
+{{% grid-cell %}}
+
+`{{%/* table "fixedLayout" "center" */%}}`
+
+{{% table "fixedLayout" "center" %}}
+
+header1 | long-header-2
+--- | ---
+1 | 2
+3 | 4
+
+{{% /table %}}
+{{% /grid-cell %}}
+{{% /grid %}}
+
+{{% grid %}}
+{{% grid-cell %}}
+
+`{{%/* table "noCellHighlighting" "center" */%}}`
+
+{{% table "noCellHighlighting" "center" %}}
+
+header1 | long-header-2
+--- | ---
+1 | 2
+3 | 4
+
+{{% /table %}}
+{{% /grid-cell %}}
+{{% grid-cell %}}
+
+`{{%/* table "noHeader" "condensed" "center" */%}}`
+
+{{% table "noHeader" "condensed" "center" %}}
+
+header1 | long-header-2
+--- | ---
+1 | 2
+3 | 4
+
+{{% /table %}}
+{{% /grid-cell %}}
+{{% /grid %}}
+
 
 # Provided by Hugo itself
 

--- a/content/post/id2vec.md
+++ b/content/post/id2vec.md
@@ -39,89 +39,60 @@ For example, let's take photos of cats and dogs. Given just arrays of pixels, we
 tell what is present on the images, however, imagine that we are given a black box which outputs
 the following:
 
-<style>
-table code {
-  background: none !important;
-  white-space: nowrap;
-}
-</style>
-
-<div class="table-2"></div>
+{{% text size="large" font="monospaced" %}}
+{{% table "fixedLayout" %}}
 
 | Photo                                                | Embedding |
 |:----------------------------------------------------:|:---------:|
-| ![one cat](/post/id2vec/cat_1_240.jpg)               |  `[1, 0]` |
-| ![one dog](/post/id2vec/dog_1_240.jpg)               |  `[0, 1]` |
-| ![five cats](/post/id2vec/cat_5_240.jpg)             |  `[5, 0]` |
-| ![four dogs](/post/id2vec/dog_4_240.jpg)             |  `[0, 4]` |
-| ![one cat and one dog](/post/id2vec/cat_dog_240.jpg) |  `[1, 1]` |
+| ![one cat](/post/id2vec/cat_1_240.jpg)               |   [1, 0]  |
+| ![one dog](/post/id2vec/dog_1_240.jpg)               |   [0, 1]  |
+| ![five cats](/post/id2vec/cat_5_240.jpg)             |   [5, 0]  |
+| ![four dogs](/post/id2vec/dog_4_240.jpg)             |   [0, 4]  |
+| ![one cat and one dog](/post/id2vec/cat_dog_240.jpg) |   [1, 1]  |
 
+{{% /table %}}
+{{% /text %}}
 
-<style>
-.table-2 + table th {
-  width: 50%;
-}
+Apart from the easy classification, we are now able to easily estimate the semantic difference between the images:
 
-.table-2 + table td {
-  font-size: 2em;
-}
-
-.table-blank + table {
-  margin: 1em 0;
-  border: none !important;
-}
-
-.table-blank + table thead, .table-blank + table th {
-  height: 0;
-  padding: 0 !important;
-}
-
-.table-blank + table thead, .table-blank + table th, .table-blank + table tr, .table-blank + table td {
-  background-color: rgba(0, 0, 0, 0) !important;
-  border: none !important;
-}
-</style>
-
-Apart from the easy classification, we are now able to easily estimate the semantic difference
-between the images:
-
-<style>
-.table-img-160 + table img {
-  width: 160px;
-  object-fit: contain;
-}
-.table-img-160 + table td {
-  font-size: 2em;
-}
-</style>
-
-<div class="table-blank table-img-160"></div>
+{{% text size="large" font="monospaced" %}}
+{{% table "noCellHighlighting" "noHeader" "condensed" %}}
 
 |                                          |     |                                        |     |                                        |
 |:----------------------------------------:|:---:|:--------------------------------------:|:---:|:--------------------------------------:|
-| ![one cat](/post/id2vec/cat_dog_240.jpg) | `-` | ![one dog](/post/id2vec/dog_1_240.jpg) | `=` | ![one cat](/post/id2vec/cat_1_240.jpg) |
-| `[1, 1]`                                 |     | `[0, 1]`                               |     | `[1, 0]`                               |
+| ![one cat](/post/id2vec/cat_dog_240.jpg) |  -  | ![one dog](/post/id2vec/dog_1_240.jpg) |  =  | ![one cat](/post/id2vec/cat_1_240.jpg) |
+| [1, 1]                                   |     | [0, 1]                                 |     | [1, 0]                               |
+
+{{% /table %}}
+{{% /text %}}
 
 The semantic distance is \\(||(1, 0)||_2 = 1\\). It is evident that the result of such subtraction is just a single cat.
 
-
-<div class="table-blank table-img-160"></div>
+{{% text size="large" font="monospaced" %}}
+{{% table "noCellHighlighting" "noHeader" "condensed" %}}
 
 |                                        |     |                                        |     |                                          |
 |:--------------------------------------:|:---:|:--------------------------------------:|:---:|:----------------------------------------:|
-| ![one cat](/post/id2vec/cat_1_240.jpg) | `-` | ![one dog](/post/id2vec/dog_1_240.jpg) | `=` | ![monster](/post/id2vec/monster_240.jpg) |
-| `[1, 0]`                               |     | `[0, 1]`                               |     | `[1, -1]`                                |
+| ![one cat](/post/id2vec/cat_1_240.jpg) |  -  | ![one dog](/post/id2vec/dog_1_240.jpg) |  =  | ![monster](/post/id2vec/monster_240.jpg) |
+|  [1, 0]                                |     |  [0, 1]                                |     |  [1, -1]                                 |
+
+{{% /table %}}
+{{% /text %}}
 
 The semantic distance be \\(||(1, -1)||_2 = \\sqrt{2}\\). If we had a two-way
 black box, e.g. a deep neural network trained to classify our photos, we could generate an image
 from `[1, -1]` and most likely got a terrible alien monster.
 
-<div class="table-blank table-img-160"></div>
+{{% text size="large" font="monospaced" %}}
+{{% table "noCellHighlighting" "noHeader" "condensed" %}}
 
 |                                          |     |                                        |     |                                        |
 |:----------------------------------------:|:---:|:--------------------------------------:|:---:|:--------------------------------------:|
-| ![five cats](/post/id2vec/cat_5_240.jpg) | `-` | ![one cat](/post/id2vec/cat_1_240.jpg) | `=` | ![monster](/post/id2vec/cat_4_240.jpg) |
-| `[5, 0]`                                 |     | `[1, 0]`                               |     | `[4, 0]`                               |
+| ![five cats](/post/id2vec/cat_5_240.jpg) |  -  | ![one cat](/post/id2vec/cat_1_240.jpg) |  =  | ![monster](/post/id2vec/cat_4_240.jpg) |
+|  [5, 0]                                  |     |  [1, 0]                                |     |  [4, 0]                                |
+
+{{% /table %}}
+{{% /text %}}
 
 The semantic distance is 4 which is greater than \\(\\sqrt{2}\\). Depending on the problem we solve,
 this may or may not be normal. Our result is four cats.
@@ -292,19 +263,11 @@ We extract subtokens (splitted and stemmed) from every identifier in every scope
 the corresponding elements in the co-occurrence matrix in an "all to all" fashion.
 Duplicates are discarded, that is, only unique elements are taken. The result is:
 
-<style>
-.table-small + table {
-  font-size: small;
-}
-.table-small + table th {
-  padding: 10px 5px !important;
-}
-.table-small + table td:nth-child(even), .table-small + table th:nth-child(even) {
-  background: #ecf0f1;
-}
-</style>
-
-<div class="table-small"></div>
+{{% grid %}}
+{{% scroll-panel %}}
+{{% center %}}
+{{% text size="small" %}}
+{{% table "condensed" "fixedLayout" %}}
 
 | populat | instal | apps | ready | lock | load | runtim | error | entry | app | config | create | label | improp | configur |
 |:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|:-:|
@@ -323,6 +286,12 @@ Duplicates are discarded, that is, only unique elements are taken. The result is
 | 1 | 4 | 4 | 3 | 3 | 3 | 3 | 3 | 4 | 5 | 5 | 5 | 0 | 5 | 5 |
 | 1 | 4 | 4 | 3 | 3 | 3 | 3 | 3 | 4 | 5 | 5 | 5 | 5 | 0 | 5 |
 | 1 | 4 | 4 | 3 | 3 | 3 | 3 | 3 | 4 | 5 | 5 | 5 | 5 | 5 | 0 |
+
+{{% /table %}}
+{{% /text %}}
+{{% /center %}}
+{{% /scroll-panel %}}
+{{% /grid %}}
 
 The biggest co-occurrence value is between "app" and "config" - 6 contexts.
 
@@ -539,15 +508,7 @@ iogrpc'
 
 bicycling! We all know about
 
-<style>
- .img-small + p > img {
-   width: 50%;
- }
-</style>
-
-<div class="img-small"></div>
-
-![google bicycles](/post/id2vec/google_bicycle.jpg)
+{{% caption src="/post/id2vec/google_bicycle.jpg" width="half-width" /%}}
 
 but why on earth did somebody name an entity in code like this?
 

--- a/src/css/entry.css
+++ b/src/css/entry.css
@@ -13,6 +13,10 @@ figure > figcaption {
     font-style: italic;
 }
 
+.caption-half-width > img {
+    width: 50%;
+}
+
 .scroll-panel {
     overflow: auto;
     border-radius: 5px;

--- a/src/css/entry.css
+++ b/src/css/entry.css
@@ -4,6 +4,7 @@
 
 .centered {
     text-align: center;
+    width: 100%;
 }
 
 figure > figcaption {
@@ -13,9 +14,9 @@ figure > figcaption {
 }
 
 .scroll-panel {
-    margin: 20px 0;
     overflow: auto;
     border-radius: 5px;
+    width: 100%;
 }
 
 .scroll-panel pre,
@@ -42,20 +43,18 @@ figure > figcaption {
 
 .grid2x-cell {
     width: 50%;
+    padding-right: 10px;
 }
 
-.grid2x-cell pre {
-    margin: 30px !important;
+.grid2x-cell + .grid2x-cell {
+    padding-left: 10px;
+    padding-right: 0;
 }
 
 @media (max-width: 1000px) {
     .grid2x {
         width: 100%;
         margin-left: 0;
-    }
-
-    .grid2x > div {
-        width: 50%;
     }
 }
 
@@ -64,13 +63,61 @@ figure > figcaption {
         flex-direction: column;
     }
 
-    .grid2x > div {
-        width: 100%;
-    }
-
     .grid2x-cell {
         width: 100%;
+        padding: 0 !important;
     }
+}
+
+.table-no-cell-highlighting table,
+.table-no-cell-highlighting thead,
+.table-no-cell-highlighting th,
+.table-no-cell-highlighting tr,
+.table-no-cell-highlighting td {
+    border: 0 !important;
+    background: transparent !important;
+}
+
+.table-no-header thead {
+    display: none;
+}
+
+.table-fixed-layout table {
+    table-layout: fixed;
+}
+
+@media all and (max-width: 1000px) {
+    .table-fixed-layout table {
+        table-layout: initial;
+    }
+}
+
+.table-condensed td,
+.table-condensed th {
+    padding: 2px !important;
+}
+
+.table-center td,
+.table-center th {
+    text-align: center;
+}
+
+.text-small {
+    font-size: .8em;
+}
+
+.text-large {
+    font-size: 1.4em;
+}
+
+@media all and (max-width: 768px) {
+    .text-large {
+        font-size: 1.3em;
+    }
+}
+
+.text-monospaced  {
+    font-family: "Hack", "monaco", monospace;
 }
 
 /**

--- a/themes/hugo-steam-theme/layouts/shortcodes/caption.html
+++ b/themes/hugo-steam-theme/layouts/shortcodes/caption.html
@@ -1,4 +1,4 @@
-<figure>
-    <img src="{{ .Get "src" }}" alt="{{ .Get "title" }}" />
-    <figcaption>{{ .Inner | safeHTML }}</figcaption>
+<figure {{ if in (slice "half-width") (.Get "width") }}class="caption-{{.Get "width"}}"{{ end }}>
+    <img src="{{ .Get "src" }}" {{ with .Get "title" }}alt="{{.}}"{{ end }} />
+    {{ with .Inner }}<figcaption>{{- . | safeHTML -}}</figcaption>{{ end }}
 </figure>

--- a/themes/hugo-steam-theme/layouts/shortcodes/table.html
+++ b/themes/hugo-steam-theme/layouts/shortcodes/table.html
@@ -1,0 +1,7 @@
+<div class="
+    {{ if in .Params "noCellHighlighting" }}table-no-cell-highlighting{{end}}
+    {{ if in .Params "noHeader" }}table-no-header{{end}}
+    {{ if in .Params "fixedLayout" }}table-fixed-layout{{end}}
+    {{ if in .Params "condensed" }}table-condensed{{end}}
+    {{ if in .Params "center" }} table-center{{end}}
+">{{ .Inner }}</div>

--- a/themes/hugo-steam-theme/layouts/shortcodes/text.html
+++ b/themes/hugo-steam-theme/layouts/shortcodes/text.html
@@ -1,0 +1,4 @@
+<div class="
+    {{ if in (slice "small" "large") (.Get "size") }}text-{{ .Get "size" }}{{end}}
+    {{ if in (slice "monospaced") (.Get "font") }}text-{{ .Get "font" }}{{end}}
+">{{ .Inner }}</div>

--- a/themes/hugo-steam-theme/static/css/screen.css
+++ b/themes/hugo-steam-theme/static/css/screen.css
@@ -566,7 +566,6 @@ a.archive-link {
 /* Tables */
 table {
   width: 100%;
-  font-family: "Open Sans", "Helvetica Neue", Helvetica, Arial, "Nimbus L", sans-serif;
   border-collapse: collapse;
   margin: 1em 0 3em;
 }
@@ -912,6 +911,7 @@ article.post ul ul li:before {
 
 article.post table {
   border: 1px solid #737373;
+  margin: 30px 0;
 }
 
 article.post table tr,


### PR DESCRIPTION
Closes https://github.com/src-d/backlog/issues/1098

Considering the discussion with @marnovo [abour HTML, CSS and custom layouts](https://github.com/src-d/backlog/issues/1098) for blog posts, I created some new reusable shortcodes and document and apply them to the `id2vec` post.

- [table](https://blog-staging.srcd.run/documentation/shortcodes/#text)
- [text](https://blog-staging.srcd.run/documentation/shortcodes/#table)

Here is a screenshot of the blog, highlighting in the modified items.

![blog](https://user-images.githubusercontent.com/2437584/32379870-00a1ab72-c0af-11e7-8d40-9b01e524978e.png)
