### PR TITLE
List archived posts

### DIFF
--- a/themes/hugo-steam-theme/layouts/archive/list.html
+++ b/themes/hugo-steam-theme/layouts/archive/list.html
@@ -1,0 +1,1 @@
+{{ partial "skeleton" (dict "ctx" . "type" "list" "section" "archive" ) }}


### PR DESCRIPTION
- archived posts are not shown in the landing nor the blog home
- archived posts will be available under https://blog.sourced.tech/archive