### PR TITLE
Update skeleton-list.html

### DIFF
--- a/themes/hugo-steam-theme/layouts/partials/skeleton-list.html
+++ b/themes/hugo-steam-theme/layouts/partials/skeleton-list.html
@@ -14,7 +14,7 @@
             <section class="post-excerpt">
                 {{ if isset .Params "image" }}
                     <div class="image"
-                    style="background-image:url({{.Params.image}})" /></div>
+                    style="background-image:url({{.Params.image}})"></div>
                 {{end}}
                 <a class="excerptlink" href="{{ .Permalink }}" data-tracked>
                     <p>{{ .Description | markdownify }}</p>


### PR DESCRIPTION
Fix HTML issue

This issue is well handled by browsers; but more naive programs (minifiers, parsers) may consider this as a self-closing div directly followed by another closing div, which causes a different output