### PR TITLE
new short-code to embed code

### DIFF
--- a/themes/hugo-steam-theme/layouts/shortcodes/code.html
+++ b/themes/hugo-steam-theme/layouts/shortcodes/code.html
@@ -1,0 +1,4 @@
+<pre><code {{ if eq (len .Params) 2 }}class="language-{{ .Get 1 }}"{{ end }}>
+        {{- printf "/static%s/" (.Get 0) | readFile -}}
+</code></pre>
+<a class="pre-caption" href="{{ .Get 0 }}">download code</a>

--- a/themes/hugo-steam-theme/static/css/screen.css
+++ b/themes/hugo-steam-theme/static/css/screen.css
@@ -69,6 +69,11 @@ pre {
   word-wrap: break-word;
   background-color: #f7f7f7;
 }
+.pre-caption {
+  display: block;
+  text-align: right;
+  margin-top: -1.5em;
+}
 code {
   font-family: monospace;
   font-size: 0.85em;


### PR DESCRIPTION
Previously we were using the triple backtick to indicate code, copy pasting code into the post.

As @dpordomingo [proposed](https://github.com/src-d/blog/pull/191#issuecomment-370466180) I created a new short-code named `code` which given the highlighting language.

So we can replace sections like this one:

<img width="315" alt="screen shot 2018-04-09 at 3 26 29 pm" src="https://user-images.githubusercontent.com/2237452/38526635-f5d15d7c-3c0b-11e8-8f5f-aa3ba7951ed4.png">

which is rendered as: 

<img width="673" alt="screen shot 2018-04-09 at 3 26 18 pm" src="https://user-images.githubusercontent.com/2237452/38526650-fef55c96-3c0b-11e8-92d6-699fce98f31f.png">

With a simple short code call:

```md
{{% code "/post/c-on-bigquery/udf.js" javascript %}}
```

Which displays as:
<img width="789" alt="screen shot 2018-04-09 at 3 37 17 pm" src="https://user-images.githubusercontent.com/2237452/38526663-0b33dac8-3c0c-11e8-8158-c5461a796009.png">

Note that the parameters are positional and the highlight language is optional.