### PR TITLE
Maintenance: highlight, .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@ package-lock.json
 .env
 .env.local
 .DS_Store
+
+# intellij
+.idea
+
+# python - used to prepare the content sometimes
+**/.ipynb_checkpoints

--- a/content/post/difftree.md
+++ b/content/post/difftree.md
@@ -71,7 +71,7 @@ The practical implications of this are:
     in lexicographic order enumerates them the same way as the `tree` command
     line tool:
 
-    ```text
+    ```nohighlight
     LICENSE
     lib
     lib/lib.go
@@ -135,7 +135,7 @@ impossible, even though they are quite popular
 In line with what we have explained so far, this is a sensible representation of
 Git trees in Go:
 
-```text
+```nohighlight
 type Noder interface {
         Name()     string
         Hash()     []byte
@@ -145,7 +145,7 @@ type Noder interface {
 
 The path to a node in a tree will look something like this:
 
-```text
+```nohighlight
 type Path []Noder // beginning from the root
                   // and ending with the node itself
 ```
@@ -153,7 +153,7 @@ type Path []Noder // beginning from the root
 I recommend `Path` to implement `Noder` so that you can treat paths as
 nodes when needed:
 
-```text
+```nohighlight
 // assuming the receiver is not the empty slice…
 func (p Path) last() Noder       { return p[len(p)-1] }
 func (p Path) Name() string      { return p.last().Name() }
@@ -200,7 +200,7 @@ The output of our tree comparator will be a list of changes, that applied to the
 A tree will turn it into the B tree.  A change in this context is defined as an
 action and the involved paths. We can represent them as follows in Go:
 
-```text
+```nohighlight
 type Action int
 
 const (
@@ -222,7 +222,7 @@ between two trees:
 -   Inserting a `lib/foo.go` file will be represented as a single insertion
     action, from `nil` to the path of the new file:
 
-    ```text
+    ```nohighlight
     fooDotGo := ...  // the node for the 'foo.go' file
     lib := ...       // the node for B's 'lib' directory (contains the new fooDotGo)
     root := ...      // the root node (contains lib)
@@ -238,7 +238,7 @@ between two trees:
 -   A modification of the contents of `lib/lib.go` is represented as the single
     change too, from A's `lib/lib.go` to B's `lib/lib.go`:
 
-    ```text
+    ```nohighlight
     libDotGoA := ...  // A's 'lib.go' file
     libA := ...       // A's 'lib' directory
     rootA := ...      // A's root node
@@ -259,7 +259,7 @@ between two trees:
 -   Renaming `lib/lib.go` to `lib/foo.go` needs two changes: deleting A's
     `lib/lib.go` and inserting B's `lib/foo.go`.
 
-    ```text
+    ```nohighlight
     libDotGo := ... // A's 'lib.go' file
     libA := ...     // A's 'lib' directory
     rootA := ...    // A's root node
@@ -289,7 +289,7 @@ between two trees:
 Now that we know how to represent changes between two trees, we can already
 write down the signature of our difftree function:
 
-```text
+```nohighlight
 func DiffTree(a, b Noder) []Change
 ```
 
@@ -330,7 +330,7 @@ greater than the latter when they are compared as simple strings.  The proper wa
 to compare paths is to compare ancestor names between them, making one step at
 a time:
 
-```text
+```nohighlight
 // Compare returns -1, 0 or 1 if the path p comes before, at the same time or
 // after the path o, in lexicographic depth-first order; for example:
 //
@@ -403,7 +403,7 @@ interesting details:
 
 Taking those into account, the iterator type will look something like this:
 
-```text
+```nohighlight
 type Iterator interface {
         Next() Path // skips directory contents
         Step() Path // descends into directories

--- a/content/post/meetup-blame.md
+++ b/content/post/meetup-blame.md
@@ -24,7 +24,7 @@ code or who is to blame for a bug }:-).
 
 For example, let's blame `src/bufio/bufio.go` from the standard Go Distribution:
 
-```text
+```nohighlight
 $ git blame src/bufio/bufio.go
 [...]
 64776da4 src/pkg/bufio/bufio.go (Rob Pike          2011-12-13 15:07:17 -0800  40) const minReadBufferSize = 16
@@ -133,7 +133,7 @@ Given two files, the `diff` command will return the _line edits_ you have to
 perform to one of them, to turn it into the other. For example: given the files
 `a.txt` and `b.txt`...
 
-```text
+```nohighlight
 $ cat a.txt
 aaa
 aaaaa
@@ -148,7 +148,7 @@ AAAAA
 
 The `diff` of both files would be:
 
-```text
+```nohighlight
 $ diff a.txt b.txt
 0a1,2
 > bb

--- a/content/post/minhashcuda.md
+++ b/content/post/minhashcuda.md
@@ -275,8 +275,6 @@ phidang/first-django-blog
 
 The complete dataset is published on [data.world](https://data.world/vmarkovtsev/github-duplicate-repositories).
 
-<script async src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-AMS_CHTML"></script>
-
 <style>
 p.caption {
   margin-top: -16px;

--- a/src/css/entry.css
+++ b/src/css/entry.css
@@ -120,7 +120,7 @@ figure > figcaption {
     }
 }
 
-.text-monospaced  {
+.text-monospaced {
     font-family: "Hack", "monaco", monospace;
 }
 
@@ -128,16 +128,27 @@ figure > figcaption {
  * Highlight.JS
  */
 
-.hljs-keyword {
+.hljs-keyword,
+.hljs-tag,
+.hljs-title,
+.hljs-header {
     color: #C3D31B;
 }
 
 .hljs-built_in,
-.hljs-params {
+.hljs-params,
+.hljs-attribute,
+.hljs-emphasis,
+.hljs-strong,
+.hljs-operator {
     color: #e66cd7;
 }
 
 .hljs-string,
-.hljs-number {
+.hljs-number,
+.hljs-value,
+.hljs-bullet,
+.hljs-code,
+.hljs-comment {
     color: #3EB1D0;
 }


### PR DESCRIPTION
* gitignore missed some files
* `text` is an invalid type for our highlighter which is based on highlight.js, the proper one is `nohighlight`
* more highlight classes supported in the theme
* remove redundant mathjax inclusion