### PR TITLE
add a note on line length for blog posts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -110,6 +110,9 @@ draft: true
 
 Whatever content in `markdown` format.
 
+_NOTE_: Write in short lines, soft limit on 80 characters, to facilitate
+line comments on GitHub.
+
 ```
 IMPORTANT: `authorKeyName` must exist in [data/authors.yml](data/authors.yml)
 


### PR DESCRIPTION
Signed-off-by: Francesc Campoy <campoy@golang.org>