### PR TITLE
Allow cors for projector.tensorflow.org origin

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -12,6 +12,11 @@
 
     ext .html
 
+    cors / {
+        origin            http://projector.tensorflow.org
+        methods           GET
+    }
+
     errors {
         404 404.html
     }


### PR DESCRIPTION
fix #240

I added
```yml
    cors / {
        origin            http://projector.tensorflow.org
        methods           GET
    }
```

Let me know @vmarkovtsev if it suits you.
If it is not enough, could you please provide one of the following:
- the cors requirements from `projector.tensorflow.org`
- the error log that you received

It's now deployed into Staging, so you can test it;
if you now run:
```shell
$ curl -vvv --head -X OPTIONS -H "Origin: http://projector.tensorflow.org" https://blog-staging.srcd.run
```
you'll obtain:
```shell
> OPTIONS / HTTP/1.1
> Host: blog-staging.srcd.run
> User-Agent: curl/7.47.0
> Accept: */*
> Origin: http://projector.tensorflow.org
> 
< HTTP/1.1 200 OK
HTTP/1.1 200 OK
< Access-Control-Allow-Origin: http://projector.tensorflow.org
...
```