### PR TITLE
Dev environment in docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git/
+node_modules/
+.hugo/
+public/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,45 @@
-FROM abiosoft/caddy
+# STAGE dev: Development environment
+FROM node:10-alpine@sha256:fcd9b3cb2fb21157899bbdb35d1cdf3d6acffcd91ad48c1af5cb62c22d2d05b1 \
+    AS dev
+
+WORKDIR /src-d/blog
+
+RUN apk add --no-cache make bash ca-certificates
+
+COPY Makefile webpack.config.js ./
+COPY package.json yarn.lock ./
+COPY ./src ./src
+
+RUN set -x \
+    && apk add --no-cache --virtual .deps curl \
+    && make project-dependencies \
+    && yarn cache clean \
+    && apk del .deps
+
+COPY config.yaml .terminusMaximus ./
+
+CMD ["make", "serve"]
+
+################################
+# Developement image stops here
+# use '--target dev' on build to break here
+
+# STAGE build: Build environment
+FROM dev AS build
+
+COPY ./content ./content
+COPY ./data ./data
+COPY ./static ./static
+COPY ./themes ./themes
+
+RUN make build
+
+CMD ["make", "hugo-server"]
+
+# STAGE runtime: Production environment
+
+FROM abiosoft/caddy@sha256:918431577452be0f3117fa056b1280f0ef0cd2f002473f405f375495eed168f4 \
+    AS runtime
+
 COPY Caddyfile /etc/Caddyfile
-COPY public /var/www/public
+COPY --from=build /src-d/blog/public /var/www/public

--- a/Dockerfile
+++ b/Dockerfile
@@ -38,8 +38,19 @@ CMD ["make", "hugo-server"]
 
 # STAGE runtime: Production environment
 
-FROM abiosoft/caddy@sha256:918431577452be0f3117fa056b1280f0ef0cd2f002473f405f375495eed168f4 \
+FROM alpine:3.8@sha256:621c2f39f8133acb8e64023a94dbdf0d5ca81896102b9e57c0dc184cadaf5528 \
     AS runtime
+
+ARG CADDY_PLUGINS="http.cors"
+
+RUN set -x \
+    && apk add --no-cache --virtual .caddydeps tar curl \
+    && curl -sL "https://caddyserver.com/download/linux/amd64?plugins=${CADDY_PLUGINS}&license=personal&telemetry=off" \
+    | tar --no-same-owner -C /usr/bin/ -xz caddy \
+    && chmod +x /usr/bin/caddy \
+    && apk del .caddydeps
 
 COPY Caddyfile /etc/Caddyfile
 COPY --from=build /src-d/blog/public /var/www/public
+
+CMD ["caddy", "--conf", "/etc/Caddyfile"]


### PR DESCRIPTION
### Summary

Needs #255 #252 
Related #173 

Update the dockerfile to use it as a dev env

Final runtime image size is `88 MB` compressed
It's available to test on the docker hub: [zadki3l/src-d-blog](https://hub.docker.com/r/zadki3l/src-d-blog/tags/)

Try it now with: 
```sh
docker run --rm -it zadki3l/src-d-blog
```

### Other Information

This dockerfile leverage multiple stages builds:
- `dev`: Install dependencies
- `build`: copy project files and build hugo static website
- `runtime`: The final production image with caddy

I recommend to append `-u "$(id -u):$(id -g)"` to the `docker run` command to keep permissions clean.

Usage
```sh
# Build the dev image
docker build -t src-d/blog:dev --target dev .
# Build the runtime final image
docker build -t src-d/blog .

# Run dev image (default to `watch:test` script)
docker run --rm -it -u "$(id -u):$(id -g)" -v $PWD/src:/src-d/blog/src -v $PWD/content:/src-d/blog/content -v $PWD/data:/src-d/blog/data -v $PWD/static:/src-d/blog/static -v $PWD/themes:/src-d/blog/themes src-d/blog:dev
# Run dev image (`build` to external folder)
mkdir -p public
docker run --rm -it -u "$(id -u):$(id -g)" -v $PWD/src:/src-d/blog/src -v $PWD/content:/src-d/blog/content -v $PWD/data:/src-d/blog/data -v $PWD/static:/src-d/blog/static -v $PWD/themes:/src-d/blog/themes -v $PWD/public:/src-d/blog/public 
 src-d/blog:dev nexmo:dev make build

# Handy dev alias (run from repo folder)
alias src-d-blog-dev="mkdir -p $PWD/public; docker run --rm -it -u '$(id -u):$(id -g)' -v $PWD/src:/src-d/blog/src -v $PWD/content:/src-d/blog/content -v $PWD/data:/src-d/blog/data -v $PWD/static:/src-d/blog/static -v $PWD/themes:/src-d/blog/themes -v $PWD/public:/src-d/blog/public 
 src-d/blog:dev nexmo:dev make"
# and then:
src-d-blog-dev build
src-d-blog-dev serve
src-d-blog-dev any-make-target

# Run prod image (port 8080)
docker run -it -p 8080:80 src-d/blog
```