### PR TITLE
[Issue #181] Fix spurious bullets in ordered lists

### DIFF
--- a/themes/hugo-steam-theme/static/css/screen.css
+++ b/themes/hugo-steam-theme/static/css/screen.css
@@ -914,6 +914,10 @@ article.post ul ul li:before {
   border: 1px solid #adb6bf;
 }
 
+article.post ol > li:before {
+  content: none;
+}
+
 article.post table {
   border: 1px solid #737373;
   margin: 30px 0;


### PR DESCRIPTION
The small circles in ordered lists show up when the ordered list is nested inside an unordered list, matching the "article.post ul li:before" rule. I made a new rule stating that li nodes immediately inside ordered lists should not have that shadow anymore.